### PR TITLE
Release 1.6.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # vendor/
 
 patch_*.sh
+patch.sh
 revert_*.sh
-
+revert.sh
 .husky

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -38,9 +38,6 @@ func (generator *Generator) Open() {
 
 	for _, name := range files {
 		fileLoc := fmt.Sprintf("%s.sh", name)
-		if generator.Environment == "dev" {
-			fileLoc = fmt.Sprintf("%s_dev.sh", name)
-		}
 		fd, err := os.Create(fileLoc)
 		os.Chmod(fileLoc, 0o755)
 

--- a/patches/autotune.yaml
+++ b/patches/autotune.yaml
@@ -143,5 +143,22 @@ body: |
   else
       echo "$FILE_MAX_KEY already $FILE_MAX_CURRENT, nothing to do."
   fi
+  # ============================================================================
+  # SECTION: Maximize NIC ring buffers
+  # ============================================================================
+  # Ring buffers are hardware-dependent (ethtool, not sysctl), so we detect
+  # max values at boot and set accordingly for each active interface.
+  for IFACE in $(ip -o link show up | awk -F': ' '{print $2}' | grep -vE '^(lo|docker|br-|veth|tap|virbr)'); do
+      RX_MAX=$(ethtool -g "$IFACE" 2>/dev/null | awk '/Pre-set/,/Current/' | awk '/^RX:/{print $2}' | head -1)
+      RX_CUR=$(ethtool -g "$IFACE" 2>/dev/null | awk '/Current/,0' | awk '/^RX:/{print $2}' | head -1)
+      TX_MAX=$(ethtool -g "$IFACE" 2>/dev/null | awk '/Pre-set/,/Current/' | awk '/^TX:/{print $2}' | head -1)
+
+      if [ -n "$RX_MAX" ] && [ -n "$RX_CUR" ] && [ "$RX_CUR" -lt "$RX_MAX" ] 2>/dev/null; then
+          echo "Setting $IFACE ring buffer RX=$RX_MAX TX=$TX_MAX (was RX=$RX_CUR)"
+          ethtool -G "$IFACE" rx "$RX_MAX" tx "${TX_MAX:-$RX_MAX}" 2>/dev/null || true
+      else
+          echo "$IFACE ring buffer already at max ($RX_CUR), nothing to do."
+      fi
+  done
   # PATCHFILES END - autotune configuration
 

--- a/patches/sshd.yaml
+++ b/patches/sshd.yaml
@@ -36,7 +36,7 @@ body: |
 
   Ciphers aes128-ctr,aes192-ctr,aes256-ctr,chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
   
-  HostKeyAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss
+  HostKeyAlgorithms ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256
   
   KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
   

--- a/patches/sysctl.yaml
+++ b/patches/sysctl.yaml
@@ -61,6 +61,7 @@ body: |
 
   # TCP settings
   net.ipv4.tcp_max_syn_backlog = 65535
+  net.ipv4.tcp_syn_retries = 3                     # Fail unanswered SYN in ~7-15s (default 6 ~= 127s)
   net.ipv4.tcp_no_metrics_save = 0
   net.ipv4.tcp_moderate_rcvbuf = 1
   net.ipv4.tcp_slow_start_after_idle = 0           # Disable slow start on idle
@@ -91,7 +92,7 @@ body: |
   net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30       # TIME_WAIT state timeout
   net.netfilter.nf_conntrack_tcp_timeout_close_wait = 60     # CLOSE_WAIT state timeout
   net.netfilter.nf_conntrack_tcp_timeout_fin_wait = 120      # FIN_WAIT state timeout
-  net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 120      # SYN_SENT state timeout
+  net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 30       # SYN_SENT state timeout (lowered from 120 for scan workload)
   net.netfilter.nf_conntrack_tcp_timeout_syn_recv = 60       # SYN_RECV state timeout
   net.netfilter.nf_conntrack_tcp_timeout_unacknowledged = 300 # Unacknowledged connection timeout
 

--- a/patches/sysctl.yaml
+++ b/patches/sysctl.yaml
@@ -51,9 +51,9 @@ body: |
 
   # Socket buffer tuning
   net.core.wmem_max = 16777216
-  net.core.wmem_default = 212992
+  net.core.wmem_default = 1048576
   net.core.rmem_max = 16777216
-  net.core.rmem_default = 212992
+  net.core.rmem_default = 1048576
   net.ipv4.tcp_rmem = 4096 262144 16777216
   net.ipv4.tcp_wmem = 4096 262144 16777216
   net.ipv4.tcp_mem = 65536 131072 16777216

--- a/patches/sysctl.yaml
+++ b/patches/sysctl.yaml
@@ -90,9 +90,10 @@ body: |
 
   # Other TCP state timeouts for aggressive cleanup
   net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30       # TIME_WAIT state timeout
+  net.netfilter.nf_conntrack_tcp_timeout_close = 5            # CLOSE state timeout (terminal; finished/reset flows)
   net.netfilter.nf_conntrack_tcp_timeout_close_wait = 60     # CLOSE_WAIT state timeout
   net.netfilter.nf_conntrack_tcp_timeout_fin_wait = 120      # FIN_WAIT state timeout
-  net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 30       # SYN_SENT state timeout (lowered from 120 for scan workload)
+  net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 10       # SYN_SENT state timeout (10s; dialer abandons connects at 5s)
   net.netfilter.nf_conntrack_tcp_timeout_syn_recv = 60       # SYN_RECV state timeout
   net.netfilter.nf_conntrack_tcp_timeout_unacknowledged = 300 # Unacknowledged connection timeout
 

--- a/patches/sysctl.yaml
+++ b/patches/sysctl.yaml
@@ -15,6 +15,7 @@ body: |
   # Note: fs.file-max is overridden dynamically by autotune.yaml based on RAM
   fs.file-max = 2097152
   fs.inotify.max_user_watches = 524288
+  fs.inotify.max_user_instances = 8192
 
   # Memory management tuning
   vm.overcommit_memory = 1                        # Disable overcommit


### PR DESCRIPTION
Release 1.6.7 — sshd OpenSSH 10 / Ubuntu 26.04 compat fix + accumulated dev changes.

Commits since 1.6.6:
- fix(sshd): drop removed ssh-dss, harden HostKeyAlgorithms for OpenSSH 10
- merge chore/conntrack-syn-close-tune into dev
- perf(sysctl): syn_sent 30->10, add close=5 to trim conntrack further
- merge chore/sysctl-syn-tuning into dev
- perf(sysctl): shorten SYN_SENT timeout + add tcp_syn_retries=3
- merge feat/inotify-max-instances into dev
- feat(sysctl): raise fs.inotify.max_user_instances to 8192
- fix: increase default socket buffers and auto-maximize NIC ring buffers
- refactor: update .gitignore to include patch.sh and revert.sh, and simplify generator file creation logic
- refactor: disable busy polling and reading parameters in sysctl configuration to improve network performance
- refactor: add vm.overcommit_memory setting to sysctl configuration for improved memory management
- refactor: adjust network performance parameters for busy polling and reading to optimize system responsiveness
- docs: add package and main function documentation for clarity on patchfile tool functionality
- refactor: enhance nf_conntrack timeouts for aggressive cleanup and reduced connection tracking table size
- refactor: improve autotune script with enhanced RAM calculation, debug outputs, and nf_conntrack module loading checks
- refactor: replace rc.local script execution with systemd service for autotune.sh to ensure proper execution order and enhance reliability