### PR TITLE
Release 1.6.8 — sysctl module loading (26.04)

### DIFF
--- a/patches/modules_load.yaml
+++ b/patches/modules_load.yaml
@@ -1,0 +1,14 @@
+output: /etc/modules-load.d/patchfiles.conf
+categories:
+  - networking
+  - performance
+mode: overwrite
+commentCharacter: "#"
+commandsAfter:
+  - modprobe tcp_bbr 2>/dev/null || true
+  - modprobe nf_conntrack 2>/dev/null || true
+description:
+  Load + persist tcp_bbr and nf_conntrack. bbr congestion control (net.ipv4.tcp_congestion_control) and the net.netfilter.nf_conntrack_* tunings in sysctl.conf are backed by these loadable modules; on Ubuntu 26.04 / kernel 7.0 they are not auto-loaded, so without this the settings silently fail to apply. systemd-modules-load reads this file at boot before systemd-sysctl; revert removes it.
+body: |
+  tcp_bbr
+  nf_conntrack

--- a/patches/sysctl.yaml
+++ b/patches/sysctl.yaml
@@ -6,9 +6,11 @@ categories:
 mode: overwrite
 commentCharacter: "#"
 commandsAfter: 
+  - modprobe tcp_bbr 2>/dev/null || true
+  - modprobe nf_conntrack 2>/dev/null || true
   - sysctl -p
 description:
-  special sysctl.conf kernel tunings. lots of them were collected and tested over the time.
+  special sysctl.conf kernel tunings. lots of them were collected and tested over the time. Requires tcp_bbr + nf_conntrack modules (see modules_load.yaml) so bbr congestion control and the nf_conntrack_* keys actually apply on Ubuntu 26.04 / kernel 7.0.
 body: |
   kernel.sysrq = 0
 


### PR DESCRIPTION
fix(sysctl): load+persist tcp_bbr & nf_conntrack so bbr + nf_conntrack_* sysctls apply on Ubuntu 26.04 / kernel 7.0 (mirrors os-kickstart kernel fix). New modules_load.yaml + modprobe in sysctl.yaml; revert cleans up.