### PR TITLE
fix(sysctl): let autotune own nf_conntrack_max and tcp_max_tw_buckets

### DIFF
--- a/patches/sysctl.yaml
+++ b/patches/sysctl.yaml
@@ -114,8 +114,8 @@ body: |
   net.ipv4.tcp_low_latency = 1
 
   # Connection tracking
-  # Note: net.netfilter.nf_conntrack_max is overridden dynamically by autotune.yaml based on RAM
-  net.netfilter.nf_conntrack_max = 2097152
+  # nf_conntrack_max: owned solely by autotune.yaml (RAM_GB * 65536) -- a static value
+  # here raced it at boot and left each site with a different ceiling
 
   # Aggressive nf_conntrack cleanup to reduce connection tracking table size
   # CRITICAL: Established timeout reduced from default 5 days (432000s) to 10 minutes
@@ -138,8 +138,7 @@ body: |
   # Unacknowledged connection timeout
   net.netfilter.nf_conntrack_tcp_timeout_unacknowledged = 300
 
-  # Note: net.ipv4.tcp_max_tw_buckets is overridden dynamically by autotune.yaml based on RAM
-  net.ipv4.tcp_max_tw_buckets = 2097152
+  # tcp_max_tw_buckets: owned solely by autotune.yaml (RAM_GB * 65536)
 
   # FIN and TIME_WAIT handling
   # Slightly more conservative


### PR DESCRIPTION
## What

Drop the static `nf_conntrack_max` and `tcp_max_tw_buckets` from
`patches/sysctl.yaml` so `autotune.yaml` (RAM_GB * 65536, floor 65536) is the
single owner. Timeouts stay - they are not RAM-dependent and have no second owner.

## Why

Both keys had two owners and whichever ran last won, so the effective ceiling
depended on "did this host reboot or did patch.sh run last" rather than on RAM
or role. Same fix landed in os-kickstart (dpanic/os-kickstart#7), which is what
actually manages most of the fleet; this repo covers the hosts running
`90-patchfiles.conf` (corpkx5, tf1).

The static 2097152 was also the wrong ceiling on small hosts: 2M entries is
~700 MB-1 GB of slab, i.e. an OOM on a 1-2 GB box rather than a clean refusal of
new flows.

## Not changed

Hash sizing. Fleet-wide conntrack peak is 103635 entries against 262144 buckets
(load factor 0.40) with `chaintoolong=0` on every host measured - the hash is not
a bottleneck anywhere, so no `hashsize` tuning is warranted.

## Verified

`go build ./...`, `go vet ./...` clean. Regenerated with `go run .`: the rendered
`patch.sh` no longer assigns either key and still ships all 8 conntrack timeout
lines. Generated artifacts are not committed (CI regenerates them on release).